### PR TITLE
Include built object in repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-lib/libjexl.a


### PR DESCRIPTION
To avoid users having to build the object file for the package uses locally, this PR removes the `.gitignore` line for the `.a` file that excludes the object file.